### PR TITLE
Fair Source License → Fair Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Fair Source](https://fair.io)
 
-Not Open Source. Not closed source. Fair Source is companies meaningfully
-sharing the code for their core products under non-compete licenses.
+Not closed source. Not Open Source. Fair Source is for companies that want to
+safely share their core products. Let there be code! 🙌
 
 ## Contributions & community
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,7 @@
-# [Fair Source License](https://fair.io)
+# [Fair Source](https://fair.io)
 
-Not open source. Not closed source. The [Fair Source License](https://fair.io) allows
-everyone to see the source code and makes the software free to use for
-a limited number of users in your organization. It offers some of the
-benefits of open source while preserving the ability to charge for the
-software.
-
-[**License text (Fair Source License v0.9)**](./fair-source-license-v0.9.txt)
-
-See https://fair.io for more information.
-
-
-## How Fair Source Works
-
-The Fair Source License is a license that can be applied to software applications and their source code (in the same way as an open-source license, by adding a [LICENSE file](./fair-source-license-v0.9.txt)). It is not currently suitable for library or plugin code.
-
-Any individual user can view, download, execute, and modify Fair Source-licensed code free of charge. Up to a certain number of users from an organization can use the code for free, too. After an organization hits that user limit, it will start paying a licensing fee determined by the software publisher.
-
-> Example: Alice releases FooApp as Fair Source 25, licensed under the Fair Source License with a user limit of 25. Bob can view and modify the code and run FooApp free of charge for personal use. Up to 25 people at Bob’s company can use the code and run FooApp free of charge for business purposes. When 26 or more people at Bob’s company are using or running the code, Bob’s company must pay Alice.
-
-
-## More information
-
-See https://fair.io.
-
-* [About](https://fair.io/#about)
-* [Benefits](https://fair.io/#benefits)
-* [FAQ](https://fair.io/#faq)
-* [Community](https://fair.io/#community)
-* [Media](https://fair.io/#media) (what people are saying about Fair Source)
-
+Not Open Source. Not closed source. Fair Source is companies meaningfully
+sharing the code for their core products under non-compete licenses.
 
 ## Contributions & community
 

--- a/fair.io/index.html
+++ b/fair.io/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="description" content="Not Open Source. Not closed source. Fair Source is companies meaningfully sharing the code for their core products under non-compete licenses.">
+        <meta name="description" content="Not Open Source. Not closed source. Fair Source celebrates companies meaningfully sharing their core products under non-compete licenses.">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"/>
         <meta name="mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-capable" content="yes">
@@ -18,7 +18,7 @@
         <meta property="og:site_name" content="Fair Source License">
         <meta property="og:title" content="Fair Source License">
         <meta property="og:url" content="https://fair.io/">
-        <meta property="og:description" content="Not Open Source. Not closed source. Fair Source is companies meaningfully sharing the code for their core products under non-compete licenses.">
+        <meta property="og:description" content="Not Open Source. Not closed source. Fair Source celebrates companies meaningfully sharing their core products under non-compete licenses.">
 
         <title>Fair Source License</title>
         <link rel="canonical" href="https://fair.io/"/>
@@ -30,7 +30,7 @@
     <header>
       <h1>Fair Source</h1>
       <p>
-        Not Open Source. Not closed source. Fair Source is companies meaningfully sharing the code for their core products under non-compete licenses.
+        Not Open Source. Not closed source. Fair Source celebrates companies meaningfully sharing their core products under non-compete licenses.
       </p>
 
       <p>Stay tuned for more, or <a href="https://github.com/fairsource/fairsource/issues">get involved</a>.</p>

--- a/fair.io/index.html
+++ b/fair.io/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="description" content="Not closed source. Not Open Source. Fair Source is for companies that want to share their core products. Let there be code! 🙌">
+        <meta name="description" content="Not closed source. Not Open Source. Fair Source is for companies that want to safely share their core products. Let there be code! 🙌">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"/>
         <meta name="mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-capable" content="yes">
@@ -18,7 +18,7 @@
         <meta property="og:site_name" content="Fair Source">
         <meta property="og:title" content="Fair Source">
         <meta property="og:url" content="https://fair.io/">
-        <meta property="og:description" content="Not closed source. Not Open Source. Fair Source is for companies that want to share their core products. Let there be code! 🙌">
+        <meta property="og:description" content="Not closed source. Not Open Source. Fair Source is for companies that want to safely share their core products. Let there be code! 🙌">
 
         <title>Fair Source</title>
         <link rel="canonical" href="https://fair.io/"/>
@@ -30,7 +30,7 @@
     <header>
       <h1>Fair Source</h1>
       <p>
-        Not closed source. Not Open Source. Fair Source is for companies that want to share their core products. Let there be code! 🙌
+        Not closed source. Not Open Source. Fair Source is for companies that want to safely share their core products. Let there be code! 🙌
       </p>
 
       <p>Stay tuned for more, or <a href="https://github.com/fairsource/fairsource/issues">get involved</a>.</p>

--- a/fair.io/index.html
+++ b/fair.io/index.html
@@ -3,24 +3,24 @@
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="description" content="Not Open Source. Not closed source. Fair Source celebrates companies meaningfully sharing their core products under non-compete licenses.">
+        <meta name="description" content="Not closed source. Not Open Source. Fair Source is for companies that want to share their core products. Let there be code! 🙌">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"/>
         <meta name="mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-status-bar-style" content="black">
-        <meta name="keywords" content="fair source, fair source license">
+        <meta name="keywords" content="fair source">
 
         <meta name="twitter:card" content="summary">
         <meta name="twitter:site" content="@https://twitter.com/fairsrc">
         <meta name="twitter:creator" content="@fairsrc">
         <meta name="twitter:domain" content="https://fair.io/">
 
-        <meta property="og:site_name" content="Fair Source License">
-        <meta property="og:title" content="Fair Source License">
+        <meta property="og:site_name" content="Fair Source">
+        <meta property="og:title" content="Fair Source">
         <meta property="og:url" content="https://fair.io/">
-        <meta property="og:description" content="Not Open Source. Not closed source. Fair Source celebrates companies meaningfully sharing their core products under non-compete licenses.">
+        <meta property="og:description" content="Not closed source. Not Open Source. Fair Source is for companies that want to share their core products. Let there be code! 🙌">
 
-        <title>Fair Source License</title>
+        <title>Fair Source</title>
         <link rel="canonical" href="https://fair.io/"/>
         <link rel="stylesheet" type='text/css' href="main.css"/>
         <link href='https://fonts.googleapis.com/css?family=Droid+Serif' rel='stylesheet' type='text/css'>
@@ -30,12 +30,12 @@
     <header>
       <h1>Fair Source</h1>
       <p>
-        Not Open Source. Not closed source. Fair Source celebrates companies meaningfully sharing their core products under non-compete licenses.
+        Not closed source. Not Open Source. Fair Source is for companies that want to share their core products. Let there be code! 🙌
       </p>
 
       <p>Stay tuned for more, or <a href="https://github.com/fairsource/fairsource/issues">get involved</a>.</p>
 
-      <p>(Looking for the <a href="./legacy.html">legacy license</a>?)</p>
+      <p style="font-size: smaller;">(Looking for the <a href="./legacy.html">legacy license</a>?)</p>
     </header>
   </body>
 </html>

--- a/fair.io/index.html
+++ b/fair.io/index.html
@@ -3,22 +3,22 @@
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="description" content="Not open source. Not closed source. The Fair Source License allows everyone to see the source code and makes the software free to use for a limited number of users in your organization. It offers some of the benefits of open source while preserving the ability to charge for the software.">
+        <meta name="description" content="Not Open Source. Not closed source. Fair Source is companies meaningfully sharing the code for their core products under non-compete licenses.">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"/>
         <meta name="mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-status-bar-style" content="black">
         <meta name="keywords" content="fair source, fair source license">
-		
+
         <meta name="twitter:card" content="summary">
         <meta name="twitter:site" content="@https://twitter.com/fairsrc">
         <meta name="twitter:creator" content="@fairsrc">
         <meta name="twitter:domain" content="https://fair.io/">
-		
+
         <meta property="og:site_name" content="Fair Source License">
         <meta property="og:title" content="Fair Source License">
         <meta property="og:url" content="https://fair.io/">
-        <meta property="og:description" content="Not open source. Not closed source. The Fair Source License allows everyone to see the source code and makes the software free to use for a limited number of users in your organization. It offers some of the benefits of open source while preserving the ability to charge for the software.">
+        <meta property="og:description" content="Not Open Source. Not closed source. Fair Source is companies meaningfully sharing the code for their core products under non-compete licenses.">
 
         <title>Fair Source License</title>
         <link rel="canonical" href="https://fair.io/"/>
@@ -26,237 +26,16 @@
         <link href='https://fonts.googleapis.com/css?family=Droid+Serif' rel='stylesheet' type='text/css'>
     </head>
 
-	<body>
-		<header>
-			<h1>Fair Source License</h1>
-			<p>
-				Not open source. Not closed source. The Fair Source License allows everyone to see the source code and makes the software free to use for a limited number of users in your organization. It offers some of the benefits of open source while preserving the ability to charge for the software.
-			</p>
-			<div style="text-align:center;font-size:20px;font-weight:bold;margin-top:25px;">
-            	<a href="#about">About</a>
-            	<span style="margin:10px;">&middot;</span>
-            	<a href="#benefits">Benefits</a>
-            	<span style="margin:10px;">&middot;</span>
-            	<a href="#license">License</a>
-            	<span style="margin:10px;">&middot;</span>
-            	<a href="#faq">FAQ</a>
-				<span style="margin:10px;">&middot;</span>
-            	<a href="#community">Community</a>
-				<span style="margin:10px;">&middot;</span>
-            	<a href="#media">Media</a>
-			</div>
-		</header>
-
-		<main class="content" role="main">
-			<h2 id="about">How Fair Source Works</h2>
-
-			<div style="margin-top:10px;border-bottom:#C0C0C0 1px solid;"></div>
-
-			<section class="post-excerpt">
-				<p>Any individual user can view, download, execute, and modify the code free of charge. Up to a certain number of users from an organization can use the code for free, too. After an organization hits that user limit, it will start paying a licensing fee determined by the software publisher.</p>
-
-					<blockquote>
-						<strong>Example:</strong> Alice releases FooApp as <strong>Fair Source 25</strong>, licensed under the Fair Source License with a user limit of 25. Bob can view and modify the code and run FooApp free of charge for personal use. Up to 25 people at Bob&rsquo;s company can use the code and run FooApp free of charge for business purposes. When 26 or more people at Bob&rsquo;s company are using or running the code, Bob&rsquo;s company must pay Alice.
-					</blockquote>
-
-					<p>The Fair Source License can be applied to software applications and their source code. It is <em>not</em> currently suitable for library or plugin code.</p>
-			</section>
-
-			
-			<h2 id="benefits">Benefits of Fair Source</h2>
-
-			<div style="margin-top:10px;border-bottom:#C0C0C0 1px solid;"></div>
-
-			<section class="post-excerpt">
-				<p><ul>
-					<li><strong>Fair Source allows companies to both share a product’s source code and charge for that product.</strong> Releasing a product’s source code makes it more valuable to customers by enhancing extensibility and building trust. With open source, releasing source code and charging for the product is virtually impossible. Fair Source makes doing both not just possible, but a smart option for companies invested in building the best software.</li>
-					<li><strong>Fair Source allows developers to release code publicly and get compensated by the companies that benefit from it.</strong> As a result, developers have an extra incentive to produce more (and better) products.</li>
-					<li><strong>Fair Source has the power to promote diversity within the developer community.</strong> To date, contributing to open source has been an expensive proposition for developers. You have to have a stable income and a lot of extra time to work on side projects for free, which means talented developers from underprivileged backgrounds often aren’t able to contribute. Fair Source allows developers to monetize their side projects, which means more people can afford to join the ranks of developers who pursue these initiatives.</li>
-				</ul>
-				</p>
-			</section>
-
-			
-			<h2 id="license">Fair Source License</h2>
-
-			<div style="margin-top:10px;border-bottom:#C0C0C0 1px solid;"></div>
-
-			<section class="post-excerpt">
-				<p>
-
-					<h3 id="fair-source-license-version-0-9"><a href="https://fair.io/v0.9.txt">Fair Source License, version 0.9</a></h3>
-
-					<p>Copyright &copy; <em>[year]</em> <em>[copyright owner]</em></p>
-
-					<p>Licensor: <em>[legal name of licensor]</em></p>
-
-					<p>Software: <em>[name software and version if applicable]</em></p>
-
-					<p>Use Limitation: <em>[number] users</em></p>
-
-					<p><strong>License Grant.</strong>  Licensor hereby grants to each recipient of the Software (“you”) a non-exclusive, non-transferable, royalty-free and fully-paid-up license, under all of the Licensor’s copyright and patent rights, to use, copy, distribute, prepare derivative works of, publicly perform and display the Software, subject to the Use Limitation and the conditions set forth below.</p>
-
-					<p><strong>Use Limitation.</strong>  The license granted above allows use by up to the number of users per entity set forth above (the “Use Limitation”).  For determining the number of users,  “you” includes all affiliates, meaning legal entities controlling, controlled by, or under common control with you.  If you exceed the Use Limitation, your use is subject to payment of Licensor’s then-current list price for licenses.</p>
-
-					<p><strong>Conditions.</strong>  Redistribution in source code or other forms must include a copy of this license document to be provided in a reasonable manner.  Any redistribution of the Software is only allowed subject to this license.</p>
-
-					<p><strong>Trademarks.</strong>  This license does not grant you any right in the trademarks, service marks, brand names or logos of Licensor.</p>
-
-					<p><strong>DISCLAIMER.</strong>  THE SOFTWARE IS PROVIDED &ldquo;AS IS&rdquo;, WITHOUT WARRANTY OR CONDITION, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  LICENSORS HEREBY DISCLAIM ALL LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE.</p>
-
-					<p><strong>Termination.</strong>  If you violate the terms of this license, your rights will terminate automatically and will not be reinstated without the prior written consent of Licensor.  Any such termination will not affect the right of others who may have received copies of the Software from you.</p>
-				</p>
-			</section>
-
-			
-			<h2 id="faq">FAQ</h2>
-
-			<div style="margin-top:10px;border-bottom:#C0C0C0 1px solid;"></div>
-
-			<section class="post-excerpt">
-				<p>
-
-					<h3 id="about-the-fair-source-license">About the Fair Source License</h3>
-
-					<h4 id="how-is-the-fair-source-license-similar-to-or-different-from-open-source-licenses">How is the Fair Source License similar to (or different from) open-source licenses?</h4>
-
-					<p>The Fair Source License is not an open-source license and doesn&rsquo;t intend to be an open-source license. Fair Source allows usage, redistribution, and modification when the usage is below the Use Limitation. Once an organization exceeds the Use Limitation (which is determined by the licensor), it must pay a license fee to continue doing those things.</p>
-
-					<h4 id="why-did-you-write-a-new-license-why-didn-t-you-use-gpl-mit-bsd-apache">Why did you write a new license?  Why didn’t you use GPL/MIT/BSD/Apache?</h4>
-
-					<p>Open source licenses are excellent. They have helped advance technological progress, and we love them for that. However, open source doesn’t make sense for all code. If a company open sources code that represents its <a href="http://tom.preston-werner.com/2011/11/22/open-source-everything.html">core business value</a>, it would generally fail as a business—and it couldn’t continue to build great software for you.</p>
-
-					<p>By creating the Fair Source License, we’re offering the world a new choice in between open source and closed source. Fair Source enables companies to share source code with the public and still drive revenue. It’s the best of both worlds—transparency and progress without sacrificing our businesses.</p>
-
-					<h4 id="what-does-the-license-name-fair-source-25-fair-source-50-etc-mean">What does the license name (“Fair Source 25,” “Fair Source 50,” etc.) mean?</h4>
-
-					<p>We named it “Fair Source” because you get access to source code (like you do with open source), but it’s a fair approach to licensing for code creators who want to combine sharing their code with monetization. The “25” (or other number) in the name indicates the Use Limitation, which stipulates that users must pay for the licenses once they meet the given user threshold. If you use “Fair Source 25” licensed software, for example, your organization will be required to pay a licensing fee once you hit the 25-user limit.</p>
-					<p>In addition, we recommend specifying the version of the Fair Source License you wish to apply. For example, “Fair Source 25 (v0.9).”</p>
-
-					<h4 id="how-is-the-fair-source-license-different-from-dual-gpl-commercial-licensing">How is the Fair Source License different from dual GPL/commercial licensing?</h4>
-
-					<p>In a dual GPL/commercial licensing situation, companies pay for a commercial license to prevent the GPL from “infecting” their own code. To us, that approach is less transparent and harder to understand. Fair Source is short, simple and easy to understand.  Like a dual-licensed product, you can try the software for free (up to the Use Limitation). You can redistribute the software, too—all without having to figure out complicated open-source terms.</p>
-
-					<h4 id="how-is-the-fair-source-license-different-from-shared-source">How is the Fair Source License different from “shared source”?</h4>
-
-					<p>“Shared source” referred to a model developed by Microsoft (and no longer used by Microsoft) that allowed its customers to receive source code for proprietary products to which the customers purchased binary licenses. The Fair Source License grants broader rights that apply to everyone, not just existing customers. Also, the Fair Source License explicitly allows modifications and redistribution, whereas shared source generally only permitted use of the code.</p>
-
-					<h3 id="using-the-fair-source-license">Using the Fair Source License</h3>
-
-					<h4 id="can-i-use-the-fair-source-license-for-my-own-software">Can I use the Fair Source License for my own software?</h4>
-
-					<p>Yes.  We invite the entire coding community to adopt our simple, standardized, proprietary license.  To use the Fair Source License on your own software, fill out the template available at <a href="#license">fair.io</a>.  Make sure to update the name of the owner of the copyright (i.e. you or your company), the year of the copyright notice, the name of your software, and the user limit.</p>
-
-					<h4 id="can-i-change-the-license">Can I change the license?</h4>
-
-					<p>Our license is very simple, so we don’t claim any copyright in the license text.  If you do change the license text, please remove the name “Fair Source License” to make it clear that you are not using our specific license.</p>
-
-					<h4 id="can-i-use-fair-source-software-for-myself-or-my-friends-and-family">Can I use Fair Source software for myself or my friends and family?</h4>
-
-					<p>Yes.  As an individual, you can use the software all you want for your own personal use.  The Use Limitation will only apply if you use the software for the benefit of a company.</p>
-
-					<h4 id="can-i-use-fair-source-software-inside-my-company">Can I use Fair Source software inside my company?</h4>
-
-					<p>Yes. You must pay a license fee if your organization has more people using the software than the specified Use Limitation.
-						For example, let’s say the software is licensed as Fair Source 25 (i.e., the Use Limitation is 25 users). If less than 25 people use the software within your company, the software is free.  If 25 or more people use the software, your company must pay a license fee to use the software.</p>
-
-					<h4 id="what-if-the-licensor-decides-to-change-the-use-limitation-in-the-future">What if the licensor decides to change the Use Limitation in the future?</h4>
-
-					<p>The licensor may change the Use Limitation in the future, but you will always be able to use any Fair Source software under the least restrictive license offered for that software.  For example, if we changed the limit to 50 users, we would refer to the “Fair Source 50 License” and users could benefit from this less restrictive limit. If we changed the limit to 20 users, we would refer to the “Fair Source 20 license” and users would still have the option to use the “Fair Source 50 license,” which is less restrictive. Just make sure the new limits apply to the software you are actually using—we may offer different products under different Use Limitations.</p>
-
-					<h4 id="can-i-use-fair-source-code-in-a-different-open-source-project">Can I use Fair Source code in a different open-source project?</h4>
-
-					<p>No. Unlike open source, Fair Source has a Use Limitation built into the license. This means the Fair Source license will not be compatible with your project’s open source license.</p>
-
-					<h4 id="can-i-use-fair-source-code-in-the-code-base-for-my-commercial-closed-source-product">Can I use Fair Source code in the code base for my commercial, closed-source product?</h4>
-
-					<p>Probably not. If your proprietary license includes the Use Limitation, it might be compatible with the Fair Source license.  However, we strongly discourage incorporating Fair Source licensed software into proprietary projects.  Your customers would be better off using the software under our license so that you are not responsible for policing the Use Limitation.</p>
-
-					<h4 id="if-i-modify-the-source-code-can-i-redistribute-my-modified-version-under-the-mit-license">If I modify the source code, can I redistribute my modified version under the MIT License?</h4>
-
-					<p>No. Your modified version consists of the original software (which is under the Fair Source License) and your modifications, which together constitute a derivative work of the original software.  The license does not grant you the right to redistribute under a license like MIT without the Use Limitation.</p>
-
-					<h4 id="if-i-contribute-a-patch-to-your-project-what-license-applies-to-the-patch">If I contribute a patch to your project, what license applies to the patch?</h4>
-
-					<p>As with many types of licenses, a project under the Fair Source License will require contributors to sign Contributor License Agreements. These agreements grant rights to the project’s owner. Once the agreements are signed, any patches will be placed under the same license as the rest of the project.  Many Contributor License Agreements will work with Fair Source.  If you are asked to sign one, we advise you to review its terms carefully.</p>
-
-					<h4 id="my-fair-source-license-terminated-automatically-can-i-fix-the-violation">My Fair Source License terminated automatically. Can I fix the violation?</h4>
-
-					<p>If you’ve made a mistake and violated the license, contact the licensor for a reinstatement. Please note that going over the Use Limitation is not a violation of the license and will not terminate your license, but it will mean you are obligated to pay fees for the additional use.</p>
-
-					<h4 id="what-if-i-want-different-license-terms">What if I want different license terms?</h4>
-
-					<p>Contact the licensor. They may be able to partner with you to figure out what will work best for your company.</p>
-
-					<h3 id="understanding-the-use-limitation">Understanding the Use Limitation</h3>
-
-					<h4 id="what-counts-as-using-fair-source-licensed-software-with-respect-to-the-use-limitation-e-g-25-user-limit">What counts as “using” Fair Source licensed software with respect to the Use Limitation (e.g., 25-user limit)?</h4>
-
-					<p>The license doesn’t define “use” exactly because the way people deploy software changes all the time. Instead, it relies on a common-sense definition. For example, executing the software, modifying the code, or accessing a running copy of the software constitutes “use.” If your colleague runs the software on your local network and you access it from your web browser, that behavior would constitute “use.”  Just viewing or downloading the software does not constitute “use.”  You also are able change users on the license in a reasonable way (such as when one user leaves your company and another joins).</p>
-
-					<h4 id="how-will-i-know-if-my-company-exceeds-the-use-limitation">How will I know if my company exceeds the Use Limitation?</h4>
-
-					<p>We recommend tracking the number of users who use the software internally, as you would for all other commercial software that charges per user. Products licensed under Fair Source may track and display usage data and alert the licensor if the Use Limitation is exceeded, but because you have the source code, the licensor can’t stop you from removing that functionality. We trust the software community to report fair and accurate usage numbers in line with the ethos of Fair Source.</p>
-
-					<h4 id="am-i-responsible-for-knowing-who-within-my-organization-is-already-using-fair-source-software">Am I responsible for knowing who within my organization is already using Fair Source software?</h4>
-
-					<p>Yes. If you are working for a company, we recommend checking with your engineering manager to make sure you don’t accidentally go over your organization’s Use Limitation. If you’re unsure about anything, contact the licensor.</p>
-
-					<h3 id="additional-questions">Additional Questions</h3>
-
-					<h4 id="can-i-use-fair-source-licensed-products-to-develop-software-that-will-be-licensed-under-different-licenses">Can I use Fair Source-licensed products to develop software that will be licensed under different licenses?</h4>
-
-					<p>Yes, as long as you don’t use any of the Fair Source-licensed code in the software you’re developing.</p>
-
-					<h4 id="who-created-the-license">Who created the license?</h4>
-
-					<p>Fair Source was created by <a href="https://sourcegraph.com">Sourcegraph</a> and drafted by <a href="https://github.com/heathermeeker">Heather Meeker</a>.</p>
-				</p>
-			</section>
-
-			<h2 id="community">Community</h2>
-			<div style="margin-top:10px;border-bottom:#C0C0C0 1px solid;"></div>
-			<section>
-				<ul>
-					<li><a href="https://sourcegraph.us8.list-manage.com/subscribe?u=81d5d2fe17e49697663f46503&id=c06c993455" target="_blank"><strong>Subscribe to Fair Source License email announcements</strong></a> (low-volume)</li>
-					<li>View the <a href="https://github.com/fairsource/fairsource" target="_blank">Fair Source License repository on GitHub</a></li>
-					<li>Follow <a href="https://twitter.com/fairsrc" target="_blank">@fairsrc</a> on Twitter</li>
-				</ul>
-			</section>
-			
-			<h2 id="media">Media</h2>
-			<div style="margin-top:10px;border-bottom:#C0C0C0 1px solid;"></div>
-			<section>				
-				<p><a href="http://www.wired.com/2016/03/former-open-sourcers-ask-companies-pay-fair-share/" target="_blank"><strong>WIRED</strong> (Klint Finley):</a></p>
-				<blockquote>
-					<p><em>&hellip;the Fair Source model is one way developers are trying to strike a balance between getting paid and preserving the core values of open source.</em></p>
-				</blockquote>
-
-				<p><a href="https://www.youtube.com/watch?v=y_x-9oJ4pv0" target="_blank"><strong>Open Source, Closed Source, Fair Source</strong></a> (video of talk by Quinn Slack, Sourcegraph CEO, on why Sourcegraph created the Fair Source License)</p>
-
-				<p><a href="https://about.gitlab.com/2016/03/24/gitlab-look-at-the-fair-source-license/" target="_blank"><strong>GitLab:</strong></a>
-					<blockquote>
-						<p><em>We are very supportive of the Fair Source license and business model and believe that it will have broad acceptance into the market.</em></p>
-					</blockquote>
-
-					<p><a href="https://tldrlegal.com/license/fair-source-license-0.9-(fair-source-0.9)" target="_blank"><strong>Fair Source License on TLDRLegal</strong></a></p>
-			</section>
-		</main>
-		<footer>
-        	<a href="mailto:hello@fair.io">hello@fair.io</a>
-        	<span style="margin:0 8px;">&middot;</span>
-        	<a href="https://twitter.com/fairsrc">@fairsrc</a>
-		</footer>
-
-		<script>
-		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-			(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-		ga('create', 'UA-40540747-11', 'auto');
-		ga('send', 'pageview');
-		</script>
-
-	</body>
+  <body>
+    <header>
+      <h1>Fair Source</h1>
+      <p>
+        Not Open Source. Not closed source. Fair Source is companies meaningfully sharing the code for their core products under non-compete licenses.
+      </p>
+
+      <p>Stay tuned for more, or <a href="https://github.com/fairsource/fairsource/issues">get involved</a>.</p>
+
+      <p>(Looking for the <a href="./legacy.html">legacy license</a>?)</p>
+    </header>
+  </body>
 </html>

--- a/fair.io/legacy.html
+++ b/fair.io/legacy.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html class="no-js" prefix="og: http://ogp.me/ns#" xmlns:og="http://ogp.me/ns#">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="description" content="Not open source. Not closed source. The Fair Source License allows everyone to see the source code and makes the software free to use for a limited number of users in your organization. It offers some of the benefits of open source while preserving the ability to charge for the software.">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"/>
+        <meta name="mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-status-bar-style" content="black">
+        <meta name="keywords" content="fair source, fair source license">
+
+        <meta name="twitter:card" content="summary">
+        <meta name="twitter:site" content="@https://twitter.com/fairsrc">
+        <meta name="twitter:creator" content="@fairsrc">
+        <meta name="twitter:domain" content="https://fair.io/">
+
+        <meta property="og:site_name" content="Fair Source License">
+        <meta property="og:title" content="Fair Source License">
+        <meta property="og:url" content="https://fair.io/">
+        <meta property="og:description" content="Not open source. Not closed source. The Fair Source License allows everyone to see the source code and makes the software free to use for a limited number of users in your organization. It offers some of the benefits of open source while preserving the ability to charge for the software.">
+
+        <title>Fair Source License</title>
+        <link rel="canonical" href="https://fair.io/"/>
+        <link rel="stylesheet" type='text/css' href="main.css"/>
+        <link href='https://fonts.googleapis.com/css?family=Droid+Serif' rel='stylesheet' type='text/css'>
+    </head>
+
+	<body>
+		<header>
+			<h1>Fair Source License</h1>
+      <h2 style="text-align: center; margin: 24pt;"><span style="color: red;">Legacy Page</a> - <a href="/">See Latest</a></h2>
+			<p>
+				Not open source. Not closed source. The Fair Source License allows everyone to see the source code and makes the software free to use for a limited number of users in your organization. It offers some of the benefits of open source while preserving the ability to charge for the software.
+			</p>
+			<div style="text-align:center;font-size:20px;font-weight:bold;margin-top:25px;">
+            	<a href="#about">About</a>
+            	<span style="margin:10px;">&middot;</span>
+            	<a href="#benefits">Benefits</a>
+            	<span style="margin:10px;">&middot;</span>
+            	<a href="#license">License</a>
+            	<span style="margin:10px;">&middot;</span>
+            	<a href="#faq">FAQ</a>
+				<span style="margin:10px;">&middot;</span>
+            	<a href="#community">Community</a>
+				<span style="margin:10px;">&middot;</span>
+            	<a href="#media">Media</a>
+			</div>
+		</header>
+
+		<main class="content" role="main">
+			<h2 id="about">How Fair Source Works</h2>
+
+			<div style="margin-top:10px;border-bottom:#C0C0C0 1px solid;"></div>
+
+			<section class="post-excerpt">
+				<p>Any individual user can view, download, execute, and modify the code free of charge. Up to a certain number of users from an organization can use the code for free, too. After an organization hits that user limit, it will start paying a licensing fee determined by the software publisher.</p>
+
+					<blockquote>
+						<strong>Example:</strong> Alice releases FooApp as <strong>Fair Source 25</strong>, licensed under the Fair Source License with a user limit of 25. Bob can view and modify the code and run FooApp free of charge for personal use. Up to 25 people at Bob&rsquo;s company can use the code and run FooApp free of charge for business purposes. When 26 or more people at Bob&rsquo;s company are using or running the code, Bob&rsquo;s company must pay Alice.
+					</blockquote>
+
+					<p>The Fair Source License can be applied to software applications and their source code. It is <em>not</em> currently suitable for library or plugin code.</p>
+			</section>
+
+
+			<h2 id="benefits">Benefits of Fair Source</h2>
+
+			<div style="margin-top:10px;border-bottom:#C0C0C0 1px solid;"></div>
+
+			<section class="post-excerpt">
+				<p><ul>
+					<li><strong>Fair Source allows companies to both share a product’s source code and charge for that product.</strong> Releasing a product’s source code makes it more valuable to customers by enhancing extensibility and building trust. With open source, releasing source code and charging for the product is virtually impossible. Fair Source makes doing both not just possible, but a smart option for companies invested in building the best software.</li>
+					<li><strong>Fair Source allows developers to release code publicly and get compensated by the companies that benefit from it.</strong> As a result, developers have an extra incentive to produce more (and better) products.</li>
+					<li><strong>Fair Source has the power to promote diversity within the developer community.</strong> To date, contributing to open source has been an expensive proposition for developers. You have to have a stable income and a lot of extra time to work on side projects for free, which means talented developers from underprivileged backgrounds often aren’t able to contribute. Fair Source allows developers to monetize their side projects, which means more people can afford to join the ranks of developers who pursue these initiatives.</li>
+				</ul>
+				</p>
+			</section>
+
+
+			<h2 id="license">Fair Source License</h2>
+
+			<div style="margin-top:10px;border-bottom:#C0C0C0 1px solid;"></div>
+
+			<section class="post-excerpt">
+				<p>
+
+					<h3 id="fair-source-license-version-0-9"><a href="https://fair.io/v0.9.txt">Fair Source License, version 0.9</a></h3>
+
+					<p>Copyright &copy; <em>[year]</em> <em>[copyright owner]</em></p>
+
+					<p>Licensor: <em>[legal name of licensor]</em></p>
+
+					<p>Software: <em>[name software and version if applicable]</em></p>
+
+					<p>Use Limitation: <em>[number] users</em></p>
+
+					<p><strong>License Grant.</strong>  Licensor hereby grants to each recipient of the Software (“you”) a non-exclusive, non-transferable, royalty-free and fully-paid-up license, under all of the Licensor’s copyright and patent rights, to use, copy, distribute, prepare derivative works of, publicly perform and display the Software, subject to the Use Limitation and the conditions set forth below.</p>
+
+					<p><strong>Use Limitation.</strong>  The license granted above allows use by up to the number of users per entity set forth above (the “Use Limitation”).  For determining the number of users,  “you” includes all affiliates, meaning legal entities controlling, controlled by, or under common control with you.  If you exceed the Use Limitation, your use is subject to payment of Licensor’s then-current list price for licenses.</p>
+
+					<p><strong>Conditions.</strong>  Redistribution in source code or other forms must include a copy of this license document to be provided in a reasonable manner.  Any redistribution of the Software is only allowed subject to this license.</p>
+
+					<p><strong>Trademarks.</strong>  This license does not grant you any right in the trademarks, service marks, brand names or logos of Licensor.</p>
+
+					<p><strong>DISCLAIMER.</strong>  THE SOFTWARE IS PROVIDED &ldquo;AS IS&rdquo;, WITHOUT WARRANTY OR CONDITION, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  LICENSORS HEREBY DISCLAIM ALL LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE.</p>
+
+					<p><strong>Termination.</strong>  If you violate the terms of this license, your rights will terminate automatically and will not be reinstated without the prior written consent of Licensor.  Any such termination will not affect the right of others who may have received copies of the Software from you.</p>
+				</p>
+			</section>
+
+
+			<h2 id="faq">FAQ</h2>
+
+			<div style="margin-top:10px;border-bottom:#C0C0C0 1px solid;"></div>
+
+			<section class="post-excerpt">
+				<p>
+
+					<h3 id="about-the-fair-source-license">About the Fair Source License</h3>
+
+					<h4 id="how-is-the-fair-source-license-similar-to-or-different-from-open-source-licenses">How is the Fair Source License similar to (or different from) open-source licenses?</h4>
+
+					<p>The Fair Source License is not an open-source license and doesn&rsquo;t intend to be an open-source license. Fair Source allows usage, redistribution, and modification when the usage is below the Use Limitation. Once an organization exceeds the Use Limitation (which is determined by the licensor), it must pay a license fee to continue doing those things.</p>
+
+					<h4 id="why-did-you-write-a-new-license-why-didn-t-you-use-gpl-mit-bsd-apache">Why did you write a new license?  Why didn’t you use GPL/MIT/BSD/Apache?</h4>
+
+					<p>Open source licenses are excellent. They have helped advance technological progress, and we love them for that. However, open source doesn’t make sense for all code. If a company open sources code that represents its <a href="http://tom.preston-werner.com/2011/11/22/open-source-everything.html">core business value</a>, it would generally fail as a business—and it couldn’t continue to build great software for you.</p>
+
+					<p>By creating the Fair Source License, we’re offering the world a new choice in between open source and closed source. Fair Source enables companies to share source code with the public and still drive revenue. It’s the best of both worlds—transparency and progress without sacrificing our businesses.</p>
+
+					<h4 id="what-does-the-license-name-fair-source-25-fair-source-50-etc-mean">What does the license name (“Fair Source 25,” “Fair Source 50,” etc.) mean?</h4>
+
+					<p>We named it “Fair Source” because you get access to source code (like you do with open source), but it’s a fair approach to licensing for code creators who want to combine sharing their code with monetization. The “25” (or other number) in the name indicates the Use Limitation, which stipulates that users must pay for the licenses once they meet the given user threshold. If you use “Fair Source 25” licensed software, for example, your organization will be required to pay a licensing fee once you hit the 25-user limit.</p>
+					<p>In addition, we recommend specifying the version of the Fair Source License you wish to apply. For example, “Fair Source 25 (v0.9).”</p>
+
+					<h4 id="how-is-the-fair-source-license-different-from-dual-gpl-commercial-licensing">How is the Fair Source License different from dual GPL/commercial licensing?</h4>
+
+					<p>In a dual GPL/commercial licensing situation, companies pay for a commercial license to prevent the GPL from “infecting” their own code. To us, that approach is less transparent and harder to understand. Fair Source is short, simple and easy to understand.  Like a dual-licensed product, you can try the software for free (up to the Use Limitation). You can redistribute the software, too—all without having to figure out complicated open-source terms.</p>
+
+					<h4 id="how-is-the-fair-source-license-different-from-shared-source">How is the Fair Source License different from “shared source”?</h4>
+
+					<p>“Shared source” referred to a model developed by Microsoft (and no longer used by Microsoft) that allowed its customers to receive source code for proprietary products to which the customers purchased binary licenses. The Fair Source License grants broader rights that apply to everyone, not just existing customers. Also, the Fair Source License explicitly allows modifications and redistribution, whereas shared source generally only permitted use of the code.</p>
+
+					<h3 id="using-the-fair-source-license">Using the Fair Source License</h3>
+
+					<h4 id="can-i-use-the-fair-source-license-for-my-own-software">Can I use the Fair Source License for my own software?</h4>
+
+					<p>Yes.  We invite the entire coding community to adopt our simple, standardized, proprietary license.  To use the Fair Source License on your own software, fill out the template available at <a href="#license">fair.io</a>.  Make sure to update the name of the owner of the copyright (i.e. you or your company), the year of the copyright notice, the name of your software, and the user limit.</p>
+
+					<h4 id="can-i-change-the-license">Can I change the license?</h4>
+
+					<p>Our license is very simple, so we don’t claim any copyright in the license text.  If you do change the license text, please remove the name “Fair Source License” to make it clear that you are not using our specific license.</p>
+
+					<h4 id="can-i-use-fair-source-software-for-myself-or-my-friends-and-family">Can I use Fair Source software for myself or my friends and family?</h4>
+
+					<p>Yes.  As an individual, you can use the software all you want for your own personal use.  The Use Limitation will only apply if you use the software for the benefit of a company.</p>
+
+					<h4 id="can-i-use-fair-source-software-inside-my-company">Can I use Fair Source software inside my company?</h4>
+
+					<p>Yes. You must pay a license fee if your organization has more people using the software than the specified Use Limitation.
+						For example, let’s say the software is licensed as Fair Source 25 (i.e., the Use Limitation is 25 users). If less than 25 people use the software within your company, the software is free.  If 25 or more people use the software, your company must pay a license fee to use the software.</p>
+
+					<h4 id="what-if-the-licensor-decides-to-change-the-use-limitation-in-the-future">What if the licensor decides to change the Use Limitation in the future?</h4>
+
+					<p>The licensor may change the Use Limitation in the future, but you will always be able to use any Fair Source software under the least restrictive license offered for that software.  For example, if we changed the limit to 50 users, we would refer to the “Fair Source 50 License” and users could benefit from this less restrictive limit. If we changed the limit to 20 users, we would refer to the “Fair Source 20 license” and users would still have the option to use the “Fair Source 50 license,” which is less restrictive. Just make sure the new limits apply to the software you are actually using—we may offer different products under different Use Limitations.</p>
+
+					<h4 id="can-i-use-fair-source-code-in-a-different-open-source-project">Can I use Fair Source code in a different open-source project?</h4>
+
+					<p>No. Unlike open source, Fair Source has a Use Limitation built into the license. This means the Fair Source license will not be compatible with your project’s open source license.</p>
+
+					<h4 id="can-i-use-fair-source-code-in-the-code-base-for-my-commercial-closed-source-product">Can I use Fair Source code in the code base for my commercial, closed-source product?</h4>
+
+					<p>Probably not. If your proprietary license includes the Use Limitation, it might be compatible with the Fair Source license.  However, we strongly discourage incorporating Fair Source licensed software into proprietary projects.  Your customers would be better off using the software under our license so that you are not responsible for policing the Use Limitation.</p>
+
+					<h4 id="if-i-modify-the-source-code-can-i-redistribute-my-modified-version-under-the-mit-license">If I modify the source code, can I redistribute my modified version under the MIT License?</h4>
+
+					<p>No. Your modified version consists of the original software (which is under the Fair Source License) and your modifications, which together constitute a derivative work of the original software.  The license does not grant you the right to redistribute under a license like MIT without the Use Limitation.</p>
+
+					<h4 id="if-i-contribute-a-patch-to-your-project-what-license-applies-to-the-patch">If I contribute a patch to your project, what license applies to the patch?</h4>
+
+					<p>As with many types of licenses, a project under the Fair Source License will require contributors to sign Contributor License Agreements. These agreements grant rights to the project’s owner. Once the agreements are signed, any patches will be placed under the same license as the rest of the project.  Many Contributor License Agreements will work with Fair Source.  If you are asked to sign one, we advise you to review its terms carefully.</p>
+
+					<h4 id="my-fair-source-license-terminated-automatically-can-i-fix-the-violation">My Fair Source License terminated automatically. Can I fix the violation?</h4>
+
+					<p>If you’ve made a mistake and violated the license, contact the licensor for a reinstatement. Please note that going over the Use Limitation is not a violation of the license and will not terminate your license, but it will mean you are obligated to pay fees for the additional use.</p>
+
+					<h4 id="what-if-i-want-different-license-terms">What if I want different license terms?</h4>
+
+					<p>Contact the licensor. They may be able to partner with you to figure out what will work best for your company.</p>
+
+					<h3 id="understanding-the-use-limitation">Understanding the Use Limitation</h3>
+
+					<h4 id="what-counts-as-using-fair-source-licensed-software-with-respect-to-the-use-limitation-e-g-25-user-limit">What counts as “using” Fair Source licensed software with respect to the Use Limitation (e.g., 25-user limit)?</h4>
+
+					<p>The license doesn’t define “use” exactly because the way people deploy software changes all the time. Instead, it relies on a common-sense definition. For example, executing the software, modifying the code, or accessing a running copy of the software constitutes “use.” If your colleague runs the software on your local network and you access it from your web browser, that behavior would constitute “use.”  Just viewing or downloading the software does not constitute “use.”  You also are able change users on the license in a reasonable way (such as when one user leaves your company and another joins).</p>
+
+					<h4 id="how-will-i-know-if-my-company-exceeds-the-use-limitation">How will I know if my company exceeds the Use Limitation?</h4>
+
+					<p>We recommend tracking the number of users who use the software internally, as you would for all other commercial software that charges per user. Products licensed under Fair Source may track and display usage data and alert the licensor if the Use Limitation is exceeded, but because you have the source code, the licensor can’t stop you from removing that functionality. We trust the software community to report fair and accurate usage numbers in line with the ethos of Fair Source.</p>
+
+					<h4 id="am-i-responsible-for-knowing-who-within-my-organization-is-already-using-fair-source-software">Am I responsible for knowing who within my organization is already using Fair Source software?</h4>
+
+					<p>Yes. If you are working for a company, we recommend checking with your engineering manager to make sure you don’t accidentally go over your organization’s Use Limitation. If you’re unsure about anything, contact the licensor.</p>
+
+					<h3 id="additional-questions">Additional Questions</h3>
+
+					<h4 id="can-i-use-fair-source-licensed-products-to-develop-software-that-will-be-licensed-under-different-licenses">Can I use Fair Source-licensed products to develop software that will be licensed under different licenses?</h4>
+
+					<p>Yes, as long as you don’t use any of the Fair Source-licensed code in the software you’re developing.</p>
+
+					<h4 id="who-created-the-license">Who created the license?</h4>
+
+					<p>Fair Source was created by <a href="https://sourcegraph.com">Sourcegraph</a> and drafted by <a href="http://github.com/heathermeeker">Heather Meeker</a>.</p>
+				</p>
+			</section>
+
+			<h2 id="community">Community</h2>
+			<div style="margin-top:10px;border-bottom:#C0C0C0 1px solid;"></div>
+			<section>
+				<ul>
+					<li><a href="https://sourcegraph.us8.list-manage.com/subscribe?u=81d5d2fe17e49697663f46503&id=c06c993455" target="_blank"><strong>Subscribe to Fair Source License email announcements</strong></a> (low-volume)</li>
+					<li>View the <a href="https://github.com/fairsource/fairsource" target="_blank">Fair Source License repository on GitHub</a></li>
+					<li>Follow <a href="https://twitter.com/fairsrc" target="_blank">@fairsrc</a> on Twitter</li>
+				</ul>
+			</section>
+
+			<h2 id="media">Media</h2>
+			<div style="margin-top:10px;border-bottom:#C0C0C0 1px solid;"></div>
+			<section>
+				<p><a href="http://www.wired.com/2016/03/former-open-sourcers-ask-companies-pay-fair-share/" target="_blank"><strong>WIRED</strong> (Klint Finley):</a></p>
+				<blockquote>
+					<p><em>&hellip;the Fair Source model is one way developers are trying to strike a balance between getting paid and preserving the core values of open source.</em></p>
+				</blockquote>
+
+				<p><a href="https://www.youtube.com/watch?v=y_x-9oJ4pv0" target="_blank"><strong>Open Source, Closed Source, Fair Source</strong></a> (video of talk by Quinn Slack, Sourcegraph CEO, on why Sourcegraph created the Fair Source License)</p>
+
+				<p><a href="https://about.gitlab.com/2016/03/24/gitlab-look-at-the-fair-source-license/" target="_blank"><strong>GitLab:</strong></a>
+					<blockquote>
+						<p><em>We are very supportive of the Fair Source license and business model and believe that it will have broad acceptance into the market.</em></p>
+					</blockquote>
+
+					<p><a href="https://tldrlegal.com/license/fair-source-license-0.9-(fair-source-0.9)" target="_blank"><strong>Fair Source License on TLDRLegal</strong></a></p>
+			</section>
+		</main>
+		<footer>
+        	<a href="mailto:hello@fair.io">hello@fair.io</a>
+        	<span style="margin:0 8px;">&middot;</span>
+        	<a href="https://twitter.com/fairsrc">@fairsrc</a>
+		</footer>
+
+		<script>
+		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+			(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+		ga('create', 'UA-40540747-11', 'auto');
+		ga('send', 'pageview');
+		</script>
+
+	</body>
+</html>


### PR DESCRIPTION
Hey all. 👋 After discussions with the former maintainers, [Sentry](https://sentry.io/welcome/) is taking over maintenance of this repo. We intend to retire the Fair Source License and broaden the scope to [a wider Fair Source initiative](https://github.com/getsentry/fsl.software/issues/2) (akin to [Fair Code](https://faircode.io/) if you're familiar—we're trying to connect with those folks in both [public GitHub](https://github.com/faircode-io/faircode/pull/14) and private email to collaborate so please help make the connection if you can 😁 ). This PR moves the existing homepage to `legacy.html` and stubs out a new homepage. Please speak up if you're paying attention. I'll likely land this in a few days if I don't hear from anyone. 🙏